### PR TITLE
Consider nonsingleton for ambiguous reads in importPredictions_Nanopolish

### DIFF
--- a/src/nanocompare/meth_stats/meth_stats_common.py
+++ b/src/nanocompare/meth_stats/meth_stats_common.py
@@ -96,7 +96,7 @@ def importPredictions_Nanopolish(infileName, chr_col=0, start_col=2, strand_col=
                 start = int(tmp[start_col])
                 num_sites = int(tmp[num_motifs_col])
                 llr = float(tmp[log_lik_ratio_col])
-                if abs(llr) < llr_cutoff:
+                if abs(llr) < llr_cutoff * num_sites: # Consider all sites as a group when there are multiple sites
                     continue
 
                 meth_score = llr


### PR DESCRIPTION
For Nanopolish methyl_freq calculation:
https://github.com/liuyangzzu/nano-compare/blob/efd5f2f1659626cba3c892255ea059c79ee319d2/src/nanocompare/meth_stats/meth_stats_common.py#L98-L100

It is different from the Original [Nanopolish](https://github.com/jts/nanopolish/blob/d1d18f3e88d662f45e3a70d77d2377246b6f8f76/scripts/calculate_methylation_frequency.py#L45-L46) script: 
```
if abs(llr) < args.call_threshold * num_sites:
    continue
```

I think it should be changed into(Already included in the branch):
```python
if abs(llr) < llr_cutoff * num_sites:   
    continue
```

!! Attention: We may need to recalculate Nanopolish methylation frequency after the change